### PR TITLE
Added ability to check videos conform to codec ID (e.g. "mp42mp41")

### DIFF
--- a/buildkit/actions/techspec.js
+++ b/buildkit/actions/techspec.js
@@ -115,6 +115,9 @@ var techspec = new Action({
                         }
                     }
                 }
+                if (settings.codec_id && settings.codec_id != file.codec_id) {
+                    file.flaggedProps.push("video codec id: " + file.codec_id);
+                }
                 if (settings.audio_codec) {
                     if (settings.audio_codec instanceof Array) {
                         if (settings.audio_codec.indexOf(file.audio_codec) == -1) {
@@ -222,6 +225,7 @@ var techspec = new Action({
                                 file.video_fps = eval(video.avg_frame_rate);
                             }
                             file.video_codec = video.codec_name;
+                            file.codec_id = probeData.metadata.compatible_brands;
                         } 
 
                         if (audio) {

--- a/rubconfig.json.tmp
+++ b/rubconfig.json.tmp
@@ -42,7 +42,8 @@
                 "audio_channel_layout": "mono",
                 "video_bitrate": "1.5mb/s",
                 "video_fps": 25,
-                "video_codec": "h264"
+                "video_codec": "h264",
+                "codec_id":"mp42mp41"
             },
             "mp3": {
                 "size": "10MB",


### PR DESCRIPTION
@oliverfoster What do you think to adding something like this? Help catch those mp42isom problems etc:

m05 - TechSpec: Failed [video codec id: M4V mp42isom] course/en/video/c-75.mp4