### PR TITLE
Added checkmp4 task to verify mp4 codec ids

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ adapt-buildkit install rub
     --trackinginsert  inserts tracking ids (assumes: not -b)
     --trackingdelete  delete tracking ids (assumes: not -b)
     --trackingreset   resets tracking ids (assumes: not -b)
+    --checkmp4        checks codec id of mp4 files (assumes --codecId mp42mp41)
+    --codecId [value] set checkmp4 codec id
     -w, --watch       watch for changes (assumes: -b)
     -d, --debug       no minification, produce sourcemaps (assumes: -b)
     -f, --force       force rebuild (assumes: -b)

--- a/buildkit/actions/checkmp4.js
+++ b/buildkit/actions/checkmp4.js
@@ -52,8 +52,12 @@ var checkmp4 = new Action({
         var totalChecked = 0;
         var suspects = [];
         for (var i = 0, l = list.length; i < l; i++) {
-            checkFile( list[i], options);
-            
+            checkFile( list[i], options);   
+        }
+
+        if (list.length == 0) {
+            logger.log("checkmp4: no mp4s found", 1);
+            done(options);
         }
 
         function checkCallback(file, options) {
@@ -84,6 +88,8 @@ var checkmp4 = new Action({
                             logger.log("checkmp4: Failed [" + suspects[i].flaggedProps.join(", ") + "] " + shortenedPath, 2);
                         }
                     }
+                } else {
+                    logger.log("checkmp4: all mp4s OK", 1);
                 }
 
                 done(options);

--- a/buildkit/actions/checkmp4.js
+++ b/buildkit/actions/checkmp4.js
@@ -109,15 +109,22 @@ var checkmp4 = new Action({
                 var track = file.path;
                 probe(track, function(err, probeData) {
 
-                    /*logger.log(file.path, 1);
-                    for (var i in probeData.metadata) {
-                        logger.log(i+"="+probeData.metadata[i], 1);
-                    }*/
+                    var shortenedPath = (file.path+"").substr(options.src.length+1).replace(/\\/g, "/");
+                    var v = pluckStream(probeData, "video");
+                    var br = probeData.format.bit_rate != "N/A" ? Math.round(probeData.format.bit_rate/1000) : "";
+                    var fps = v.r_frame_rate.indexOf("/") ? eval(v.r_frame_rate) : (v.avg_frame_rate.indexOf("/") ? eval(v.avg_frame_rate) : "");
+                    var codec_name = v.codec_name || "";
+                    var codec_id = probeData.metadata.compatible_brands || "";
+                    var params = [v.width+"x"+v.height];
 
-                    var video = pluckStream(probeData, "video");
+                    if (br) params.push(br+"kbps");
+                    if (fps) params.push(fps+"fps");
+                    if (codec_name) params.push(codec_name);
+                    if (codec_id) params.push(codec_id);
 
-                    if (video) {
+                    if (v) {
                         file.codec_id = probeData.metadata.compatible_brands;
+                        logger.log("["+params.join(",")+"] "+shortenedPath,1);
                     }
 
                     checkCallback(file, options);

--- a/buildkit/actions/checkmp4.js
+++ b/buildkit/actions/checkmp4.js
@@ -1,0 +1,132 @@
+var Action = require("../libraries/Action.js");
+
+var checkmp4 = new Action({
+
+    initialize: function() {
+
+        this.deps(global, {
+            "fsext": "../libraries/fsext.js",
+            "logger": "../libraries/logger.js",
+            "fs": "fs",
+            "path": "path",
+            "_": "underscore",
+            "os": "os",
+            "probe": "../actions/resources/ffprobe.js"
+        });
+
+    },
+
+    perform: function(options, done, started) { 
+       
+        started();
+
+        if (options.root === undefined) options.root = "";
+
+        options.src = fsext.replace(options.src, options);
+        options.src = fsext.expand(options.src);
+
+        function log(text, type) {
+            if (options.logPath) {
+                logger.file(options.logPath, text, false);
+            } else {
+                logger.log(" " + text, type);
+            }
+        }
+
+        if (!probe.isSupported()) {
+            if (options.course) {
+                log(options.course + " - TechSpec: " + "Cannot find video+audio information. Unsupported platform " + os.platform(), 1);
+            } else {
+                log("TechSpec: Cannot find video+audio information. Unsupported platform " + os.platform(), 1);
+            }
+
+            done(options);
+
+            return;
+        }
+
+        var cwd = process.cwd();
+
+        var list = fsext.glob(options.src, options.globs, { dirs: false });
+        var totalChecking = list.length;
+        var totalChecked = 0;
+        var suspects = [];
+        for (var i = 0, l = list.length; i < l; i++) {
+            checkFile( list[i], options);
+            
+        }
+
+        function checkCallback(file, options) {
+
+            var extension = path.extname(file.path+"").substr(1); 
+            var supported_id = options.switches.codecId;
+
+            file.flaggedProps = [];
+
+            if (supported_id != file.codec_id) {
+                file.flaggedProps.push("video codec id: " + file.codec_id);
+            }
+            
+            if (file.flaggedProps && file.flaggedProps.length > 0) {
+                suspects.push(file);
+            }
+
+            totalChecked ++;
+            if (totalChecking === totalChecked) {
+                var failed = false;
+                if (suspects.length > 0) {
+                    failed = true;
+                    for (var i = 0, l = suspects.length; i < l; i++) {
+                        var shortenedPath = (suspects[i].path+"").substr(options.src.length+1).replace(/\\/g, "/");
+                        if (options.course) {
+                            logger.log(options.course + " - checkmp4: Failed [" + suspects[i].flaggedProps.join(", ") + "] "+ shortenedPath, 2);
+                        } else {
+                            logger.log("checkmp4: Failed [" + suspects[i].flaggedProps.join(", ") + "] " + shortenedPath, 2);
+                        }
+                    }
+                }
+
+                done(options);
+            }
+        }
+
+
+        function checkFile(file, options) {
+
+            var extension = path.extname(file.path+"").substr(1); 
+
+            var async = false;          
+
+            if (probe.isSupported()) {
+                async = true;
+
+                var track = file.path;
+                probe(track, function(err, probeData) {
+
+                    /*logger.log(file.path, 1);
+                    for (var i in probeData.metadata) {
+                        logger.log(i+"="+probeData.metadata[i], 1);
+                    }*/
+
+                    var video = pluckStream(probeData, "video");
+
+                    if (video) {
+                        file.codec_id = probeData.metadata.compatible_brands;
+                    }
+
+                    checkCallback(file, options);
+
+                });
+            }
+
+            if (!async) checkCallback(file, options);
+        }
+
+        function pluckStream(probeData, codec_type) {
+            if (!probeData) return undefined;
+            return _.findWhere(probeData.streams, {codec_type:codec_type});
+        }
+    }
+});
+
+module.exports = checkmp4;

--- a/buildkit/actions/techspec.js
+++ b/buildkit/actions/techspec.js
@@ -64,6 +64,8 @@ var techspec = new Action({
 
             totalSize += file.size;
 
+            file.flaggedProps = [];
+
             if ( options.techspec.fileSize && file.size > textSizeToBytes(options.techspec.fileSize)) {
                 file.flaggedProps.push("max filesize: " + bytesSizeToString(file.size, "MB"));
             } 
@@ -76,8 +78,6 @@ var techspec = new Action({
             
             if (options.techspec.extensions && options.techspec.extensions[extension]) {
                 var settings = options.techspec.extensions[extension];
-                
-                file.flaggedProps = [];
                 
                 if ( file.size > textSizeToBytes(settings.size)) {
                     file.flaggedProps.push("filesize: " + bytesSizeToString(file.size, "KB"));

--- a/buildkit/actions/techspec.js
+++ b/buildkit/actions/techspec.js
@@ -64,7 +64,7 @@ var techspec = new Action({
 
             totalSize += file.size;
 
-            file.flaggedProps = [];
+            if (!file.flaggedProps) file.flaggedProps = [];
 
             if ( options.techspec.fileSize && file.size > textSizeToBytes(options.techspec.fileSize)) {
                 file.flaggedProps.push("max filesize: " + bytesSizeToString(file.size, "MB"));

--- a/buildkit/configurations/actions-checkmp4.json
+++ b/buildkit/configurations/actions-checkmp4.json
@@ -1,0 +1,34 @@
+{
+	"actions": [
+		{
+			"@name": "checkmp4",
+			"@displayName": "Checking codec id of mp4 files",
+			"@action": "checkmp4",
+            "@onlyOnSwitches": [
+                "checkmp4"
+            ],
+            "@when": "start",
+			"@types": [ "builds/courses/course", "src/courses/course" ],
+			"src": "{{outputDest}}/{{course}}",
+			"globs": [
+				"**/*.mp4"
+			],
+            "logPath": "rub-check.log"
+		},
+		{
+			"@name": "checkmp4",
+			"@displayName": "Checking codec id of mp4 files",
+			"@action": "checkmp4",
+            "@onlyOnSwitches": [
+                "checkmp4"
+            ],
+			"@types": [ "src/course" ],
+            "@when": "start",
+			"src": "{{outputDest}}",
+			"globs": [
+                "**/*.mp4"
+			],
+            "logPath": "rub-check.log"
+		}
+	]
+}

--- a/buildkit/configurations/switches.json
+++ b/buildkit/configurations/switches.json
@@ -28,6 +28,20 @@
 		},
 		{
 			"on": {
+				"checkmp4": true
+			},
+			"alwaysSet": {
+				"build": false,
+				"trackinginsert": false
+			},
+			"unspecifiedSet": {
+				"build":false,
+				"trackinginsert": false,
+				"codecId": "mp42mp41"
+			}
+		},
+		{
+			"on": {
 				"forceall": true
 			},
 			"alwaysSet": {

--- a/buildkit/libraries/terminal.js
+++ b/buildkit/libraries/terminal.js
@@ -63,6 +63,8 @@ var pub = {
             .option('--trackinginsert', "inserts tracking ids (assumes: not -b)")
             .option('--trackingdelete', "delete tracking ids (assumes: not -b)")
             .option('--trackingreset', "resets tracking ids (assumes: not -b)")
+            .option('--checkmp4', "checks codec id of mp4 files (assumes --codecId mp42mp41)")
+            .option('--codecId [value]', "set checkmp4 codec id")
             .option('-w, --watch', "watch for changes (assumes: -b)")
             .option('-d, --debug', "no minification, produce sourcemaps (assumes: -b)")
             .option('-f, --force', "force rebuild (assumes: -b)")


### PR DESCRIPTION
e.g. to check all *.mp4 videos use mp42mp41 codec id:

rub --checkmp4

e.g. to check all *.mp4 videos use a specific codec id:

rub --checkmp4 --codecId "M4V mp42isom"

Also added simple bug fix for techspec task.